### PR TITLE
✨ Optimizes search query

### DIFF
--- a/Mongo.CRUD/Models/SearchOptions.cs
+++ b/Mongo.CRUD/Models/SearchOptions.cs
@@ -10,10 +10,11 @@ namespace Mongo.CRUD.Models
         /// <summary>
         /// Contructor
         /// </summary>
-        public SearchOptions(int pageNumber = 1, int pageSize = 10)
+        public SearchOptions(int pageNumber = 1, int pageSize = 10, bool enablePagination = true)
         {
             this.PageNumber = pageNumber;
             this.PageSize = pageSize;
+            this.EnablePagination = enablePagination;
         }
 
         /// <summary>
@@ -53,5 +54,10 @@ namespace Mongo.CRUD.Models
         /// Sort field
         /// </summary>
         public string SortField { get; set; }
+
+        /// <summary>
+        /// Enable pagination. Default is true.
+        /// </summary>
+        public bool EnablePagination { get; set; }
     }
 }

--- a/Mongo.CRUD/MongoCRUD.cs
+++ b/Mongo.CRUD/MongoCRUD.cs
@@ -319,10 +319,18 @@ namespace Mongo.CRUD
                 options = new SearchOptions();
             }
 
-            var findOptions = FilterBuilder.GetFindOptions<TDocument>().WithPaging(options).WithSorting(options);
+            var findOptions = FilterBuilder.GetFindOptions<TDocument>().WithSorting(options);
 
-            var documents = await this.Collection.FindAsync(filters, findOptions).Result.ToListAsync(); 
-            var count = await this.Collection.CountDocumentsAsync(filters);
+            if (options.EnablePagination)
+            {
+                findOptions.WithPaging(options);
+            }
+
+            var documents = await this.Collection.FindAsync(filters, findOptions).Result.ToListAsync();
+
+            var count = documents.Count <= options.PageSize || !options.EnablePagination ?
+                documents.Count :
+                await this.Collection.CountDocumentsAsync(filters);
 
             return new SearchResult<TDocument>
             {
@@ -355,10 +363,18 @@ namespace Mongo.CRUD
 
             filters = filters ?? FilterBuilder.GetFilterBuilder<TDocument>().Empty;
 
-            var findOptions = FilterBuilder.GetFindOptions<TDocument>().WithPaging(options).WithSorting(options);
+            var findOptions = FilterBuilder.GetFindOptions<TDocument>().WithSorting(options);
+
+            if (options.EnablePagination)
+            {
+                findOptions.WithPaging(options);
+            }
 
             var documents = await this.Collection.FindAsync(filters, findOptions).Result.ToListAsync();
-            var count = await this.Collection.CountDocumentsAsync(filters);
+
+            var count = documents.Count <= options.PageSize || !options.EnablePagination ?
+                documents.Count :
+                await this.Collection.CountDocumentsAsync(filters);
 
             return new SearchResult<TDocument>
             {


### PR DESCRIPTION
### Whats?

Optimizes search query performance to avoid unnecessary queries. 

If the returned document count is lesser than the page size, we do not need to run a additional query to return the real count because we already have the count.

