### PR TITLE
chore: reduce asymptotic time caching reflection search results

### DIFF
--- a/Mongo.CRUD.Tests/Helpers/PropertyHelperTest.cs
+++ b/Mongo.CRUD.Tests/Helpers/PropertyHelperTest.cs
@@ -61,8 +61,10 @@ namespace Mongo.CRUD.Tests.Helpers
             Assert.Equal("Value cannot be null. (Parameter 'obj')", ex.Message.Replace("\r", ""));
         }
 
-        [Fact]
-        public static void GetIndividualPropertyDetailsByPropertyName_Should_Get_Value()
+        [Theory]
+        [InlineData(nameof(MyExampleWithIdProperty.Id))]
+        [InlineData("id")]
+        public static void GetIndividualPropertyDetailsByPropertyName_Should_Get_Value(string propertyName)
         {
             // arrange
             MyExampleWithIdProperty obj = new MyExampleWithIdProperty
@@ -73,7 +75,7 @@ namespace Mongo.CRUD.Tests.Helpers
 
             // act
             var result = PropertyHelper
-                .GetIndividualPropertyDetailsByPropertyName(obj, nameof(MyExampleWithIdProperty.Id));
+                .GetIndividualPropertyDetailsByPropertyName(obj, propertyName);
 
             // assert
             Assert.NotNull(result);

--- a/Mongo.CRUD/Helpers/PropertyHelper.cs
+++ b/Mongo.CRUD/Helpers/PropertyHelper.cs
@@ -37,18 +37,10 @@ namespace Mongo.CRUD.Helpers
                 throw new ArgumentNullException(nameof(propertyName));
             }
 
-            var propertyInfo = PropertyInfoByNameCache.GetOrAdd((obj.GetType(), propertyName.Trim()), (key) =>
-            {
-                var properties = key.Type.GetProperties();
-                for (int i = 0; i < properties.Length; i++)
-                {
-                    if (properties[i].Name.Equals(key.PropertyName, StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        return properties[i];
-                    }
-                }
-                return null;
-            });
+            var propertyInfo = PropertyInfoByNameCache.GetOrAdd(
+                (obj.GetType(), propertyName.Trim()),
+                (key) => key.Type.GetProperty(key.PropertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance));
+
             if (propertyInfo != null)
             {
                 var value = propertyInfo.GetValue(obj);

--- a/Mongo.CRUD/Helpers/PropertyHelper.cs
+++ b/Mongo.CRUD/Helpers/PropertyHelper.cs
@@ -1,6 +1,8 @@
 ﻿using Mongo.CRUD.Models;
 using System;
+using System.Collections.Concurrent;
 using System.Linq;
+using System.Reflection;
 
 namespace Mongo.CRUD.Helpers
 {
@@ -9,6 +11,12 @@ namespace Mongo.CRUD.Helpers
     /// </summary>
     public static class PropertyHelper
     {
+        private static readonly ConcurrentDictionary<(Type Type, string PropertyName), PropertyInfo> PropertyInfoByNameCache
+            = new ConcurrentDictionary<(Type, string), PropertyInfo>();
+
+        private static readonly ConcurrentDictionary<(Type Type, Type AttributeType), (PropertyInfo PropertyInfo, Attribute[] Attributes)> PropertyInfoByAttributeCache
+            = new ConcurrentDictionary<(Type, Type), (PropertyInfo, Attribute[])>();
+
         /// <summary>
         /// Get single property details by property name
         /// </summary>
@@ -29,19 +37,27 @@ namespace Mongo.CRUD.Helpers
                 throw new ArgumentNullException(nameof(propertyName));
             }
 
-            foreach (var propertyInfo in obj.GetType().GetProperties())
+            var propertyInfo = PropertyInfoByNameCache.GetOrAdd((obj.GetType(), propertyName.Trim()), (key) =>
             {
-                if (propertyInfo.Name.ToLowerInvariant() == propertyName.Trim().ToLowerInvariant())
+                var properties = key.Type.GetProperties();
+                for (int i = 0; i < properties.Length; i++)
                 {
-                    var value = propertyInfo.GetValue(obj);
-                    return new PropertyDetails
+                    if (properties[i].Name.Equals(key.PropertyName, StringComparison.OrdinalIgnoreCase))
                     {
-                        PropertyInfo = propertyInfo,
-                        Value = value
-                    };
+                        return properties[i];
+                    }
                 }
+                return null;
+            });
+            if (propertyInfo != null)
+            {
+                var value = propertyInfo.GetValue(obj);
+                return new PropertyDetails
+                {
+                    PropertyInfo = propertyInfo,
+                    Value = value
+                };
             }
-
             return null;
         }
 
@@ -61,20 +77,28 @@ namespace Mongo.CRUD.Helpers
                 throw new ArgumentNullException(nameof(obj));
             }
 
-            foreach (var propertyInfo in obj.GetType().GetProperties())
+            var (propertyInfo, attributes) = PropertyInfoByAttributeCache.GetOrAdd((obj.GetType(), typeof(TAttribute)), (key) =>
             {
-                TAttribute[] attributes = (TAttribute[])propertyInfo.GetCustomAttributes(typeof(TAttribute), true);
-
-                if (attributes != null & attributes.Any())
+                var properties = key.Type.GetProperties();
+                for (int i = 0; i < properties.Length; i++)
                 {
-                    var value = propertyInfo.GetValue(obj);
-                    return new PropertyDetails<TAttribute>
+                    var attrs = (Attribute[])properties[i].GetCustomAttributes(key.AttributeType, true);
+                    if (attrs != null & attrs.Any())
                     {
-                        Attributes = attributes,
-                        PropertyInfo = propertyInfo,
-                        Value = value
-                    };
+                        return (properties[i], attrs);
+                    }
                 }
+                return (null, null);
+            });
+            if (propertyInfo != null && attributes != null) 
+            {
+                var value = propertyInfo.GetValue(obj);
+                return new PropertyDetails<TAttribute>
+                {
+                    Attributes = (TAttribute[])attributes,
+                    PropertyInfo = propertyInfo,
+                    Value = value
+                };
             }
 
             return null;

--- a/Mongo.CRUD/Helpers/PropertyHelper.cs
+++ b/Mongo.CRUD/Helpers/PropertyHelper.cs
@@ -42,7 +42,7 @@ namespace Mongo.CRUD.Helpers
                 var properties = key.Type.GetProperties();
                 for (int i = 0; i < properties.Length; i++)
                 {
-                    if (properties[i].Name.Equals(key.PropertyName, StringComparison.OrdinalIgnoreCase))
+                    if (properties[i].Name.Equals(key.PropertyName, StringComparison.InvariantCultureIgnoreCase))
                     {
                         return properties[i];
                     }


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Status

READY

### Whats?

Reduce asymptotic time for properties and attributes search using reflection.

### Why?

Turns the search properties and attributes more efficient, reducing the search by property name from O(n) and for search by attribute from O(N * M) to O(1) after the first execution.

### How?

Cache the reflection search result into ConcurrentDictionaries.

### Evidences: 

#### Benchmark result:

![image](https://github.com/ThiagoBarradas/mongo-crud-dotnet/assets/14862135/31d1f959-8e37-4c3f-8bae-5d9dff227c1c)

#### DTO with id on beginning:

![image](https://github.com/ThiagoBarradas/mongo-crud-dotnet/assets/14862135/e83cd97b-7946-4cc1-8da5-d17e841adce5)

#### DTO with id on ending:

![image](https://github.com/ThiagoBarradas/mongo-crud-dotnet/assets/14862135/c20686af-62fc-454d-a35d-490eb92cdb27)
