### PR TITLE
⬆️  Bump MongoDB.Driver from 2.10.4 to 2.28.0

### DIFF
--- a/Mongo.CRUD.Tests/Mongo.CRUD.Tests.csproj
+++ b/Mongo.CRUD.Tests/Mongo.CRUD.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.10.4" />
+    <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">

--- a/Mongo.CRUD/Mongo.CRUD.csproj
+++ b/Mongo.CRUD/Mongo.CRUD.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
-    <PackageReference Include="MongoDB.Driver" Version="2.10.4" />
+    <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Status

READY

### Whats?

Bump MongoDB.Driver from 2.10.4 to 2.28.0

### Why?

In versions < 2.15.0 there's a [memory leak when used in conjunction with Datadog.Trace](https://jira.mongodb.org/browse/CSHARP-3811)

But, this PR is updating the driver to the latest version (2.28.0) because versions < 2.19 [have vulnerabilities](https://github.com/advisories/GHSA-7j9m-j397-g4wx)

### How?

bump MongoDB.Driver from 2.10.4 to 2.28.0